### PR TITLE
Fix pdf collisions script to also work if executed in another directory

### DIFF
--- a/collisions/scripts/pdf.py
+++ b/collisions/scripts/pdf.py
@@ -27,9 +27,13 @@ if len(sys.argv) == 1:
   print("Usage: pdf.py <file1.pdf> <file2.pdf>")
   sys.exit()
 
+dummyPdf = os.path.join(sys.path[0], "dummy.pdf")
+
 os.system('mutool merge -o first.pdf %s' % sys.argv[1])
 os.system('mutool merge -o second.pdf %s' % sys.argv[2])
-os.system('mutool merge -o merged.pdf dummy.pdf %s %s' % (sys.argv[1], sys.argv[2]))
+os.system('mutool merge -o merged.pdf %s %s %s' % (dummyPdf, sys.argv[1], sys.argv[2]))
+
+
 
 with open("first.pdf", "rb") as f:
   d1 = f.read()
@@ -106,10 +110,10 @@ cleaned = cleaned.replace(
   " 65536 f \n0000000018 00000 n \n",
   1)
 
-with open("pdf1.bin", "rb") as f:
+with open(os.path.join(sys.path[0], "pdf1.bin"), "rb") as f:
   prefix1 = f.read()
 
-with open("pdf2.bin", "rb") as f:
+with open(os.path.join(sys.path[0], "pdf2.bin"), "rb") as f:
   prefix2 = f.read()
 
 file1 = prefix1 + "\n" + cleaned[192:]


### PR DESCRIPTION
If the collisions/scripts/pdf.py script gets executed in another directory
than the scripts directory, some references cannot be resolved. To fix this,
all files that are included in the repository must be referenced relative
to the script folder instead of the working dir.

With this fix it's now possible to execute the script like this:
   `python ./pocs/collisions/scripts/pdf.py some.pdf another.pdf`

or on windows:
   `python.exe .\pocs\collisions\scripts\pdf.py some.pdf another.pdf`

This merge request is a follow up of #6. As mentioned, my solution only worked on UNIX based systems, so I changed it to work also on windows.